### PR TITLE
perf(http): Shift from requests to asyncio/aiohttp

### DIFF
--- a/my_chess_style/settings/base.py
+++ b/my_chess_style/settings/base.py
@@ -153,6 +153,6 @@ CELERY_IGNORE_RESULT = False
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.redis.RedisCache",
-        "LOCATION": f"redis://:{os.getenv('CACHE_PASSWORD')}@{os.getenv('DB_HOST')}:6379",
+        "LOCATION": f"redis://default:{os.getenv('CACHE_PASSWORD')}@{os.getenv('DB_HOST')}:6379/1",
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "langchain-ollama>=0.3.6",
   "matplotlib>=3.10.1",
   "numpy>=2.2.4",
+  "palitra>=0.0.1.post1",
   "pandas>=2.2.3",
   "psycopg2>=2.9.10",
   "pyarrow>=20.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -542,6 +542,10 @@ packaging==24.2 \
     #   langsmith
     #   matplotlib
     #   pytest
+palitra==0.0.1.post1 \
+    --hash=sha256:9faac26fc232706b99a87823b82cf5f63c533576799b17d6c835a49d0e2539de \
+    --hash=sha256:a26a67e0ffe16022d4108490a674634ae5c42c555c40edcf2c863d9795dcad7b
+    # via my-chess-style
 pandas==2.2.3 \
     --hash=sha256:15c0e1e02e93116177d29ff83e8b1619c93ddc9c49083f237d4312337a61165d \
     --hash=sha256:1db71525a1538b30142094edb9adc10be3f3e176748cd7acc2240c2f2e5aa3a4 \

--- a/style_predictor/tasks.py
+++ b/style_predictor/tasks.py
@@ -1,10 +1,10 @@
-import asyncio
 import logging
 from collections import Counter, defaultdict
 from dataclasses import dataclass
 from typing import Any, Callable, NamedTuple
 from uuid import UUID
 
+import palitra
 from celery import chord, current_app, shared_task
 from celery.signals import task_postrun
 from django.core.cache import cache
@@ -312,7 +312,7 @@ def pgn_get_games_from_file(session_id: UUID, usernames: str, pgn_data: str):
 @shared_task(name=constants.GET_CHESS_COM_TASK)
 def pgn_get_chess_com_games_by_user(session_id: UUID, username: str):
     """Celery task to get chess games for user from chess.com."""
-    pgn_data: str = asyncio.run(get_chess_dot_com_games(username))
+    pgn_data: str = palitra.run(get_chess_dot_com_games(username))
     return save_file_and_queue_task(
         session_id, username, pgn_data, FileSource.CHESSDOTCOM
     )

--- a/uv.lock
+++ b/uv.lock
@@ -1488,6 +1488,7 @@ dependencies = [
     { name = "langchain-ollama" },
     { name = "matplotlib" },
     { name = "numpy" },
+    { name = "palitra" },
     { name = "pandas" },
     { name = "psycopg2" },
     { name = "pyarrow" },
@@ -1543,6 +1544,7 @@ requires-dist = [
     { name = "langchain-ollama", specifier = ">=0.3.6" },
     { name = "matplotlib", specifier = ">=3.10.1" },
     { name = "numpy", specifier = ">=2.2.4" },
+    { name = "palitra", specifier = ">=0.0.1.post1" },
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "psycopg2", specifier = ">=2.9.10" },
     { name = "pyarrow", specifier = ">=20.0.0" },
@@ -1785,6 +1787,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451 },
+]
+
+[[package]]
+name = "palitra"
+version = "0.0.1.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/81/c825f50ffd7efa9beb59d36b537117c9f3cb6b621dfc83135303579b0cb6/palitra-0.0.1.post1.tar.gz", hash = "sha256:9faac26fc232706b99a87823b82cf5f63c533576799b17d6c835a49d0e2539de", size = 7434 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/c1/51066866e83f9e390a4c17a5538faa69c7ee4f2b60b60554663e9c946574/palitra-0.0.1.post1-py3-none-any.whl", hash = "sha256:a26a67e0ffe16022d4108490a674634ae5c42c555c40edcf2c863d9795dcad7b", size = 7912 },
 ]
 
 [[package]]


### PR DESCRIPTION
We have better performance switching to aiohttp.

## Summary by Sourcery

Migrate chess.com PGN fetching to asynchronous aiohttp calls with concurrency control and retry logic, update Celery task to run the async function, and DRY up Redis URI configuration for Celery.

New Features:
- Convert get_chess_dot_com_games to an async function using aiohttp for non-blocking HTTP requests
- Introduce fetch_archive coroutine with rate-limiting handling and a semaphore to limit concurrent connections

Enhancements:
- Define a REDIS_URI constant and reuse it for Celery result backend configuration